### PR TITLE
Apply replacer logic to original data structure during transformation ra...

### DIFF
--- a/resurrect.js
+++ b/resurrect.js
@@ -324,8 +324,16 @@ Resurrect.prototype.visit = function(root, f) {
             copy = Object.create(Object.getPrototypeOf(root));
             root[this.refcode] = this.tag(copy);
             for (var key in root) {
+                var value = root[key];
                 if (root.hasOwnProperty(key)) {
-                    copy[key] = this.visit(root[key], f);
+                    if (this.replacer && value !== undefined) {
+                      // Call replacer as normal for JSON.stringify's replacer function.
+                      value = this.replacer.call(root, key, root[key]);
+                      if (value === undefined) {
+                        continue; // Do not add this key/value to the result
+                      }
+                    }
+                    copy[key] = this.visit(value, f);
                 }
             }
         }
@@ -367,6 +375,7 @@ Resurrect.prototype.stringify = function(object, replacer, space) {
         return JSON.stringify(this.handleAtom(object), replacer, space);
     } else {
         this.table = [];
+        this.replacer = replacer;
         this.visit(object, this.handleAtom.bind(this));
         for (var i = 0; i < this.table.length; i++) {
             if (this.cleanup) {
@@ -379,7 +388,8 @@ Resurrect.prototype.stringify = function(object, replacer, space) {
         }
         var table = this.table;
         this.table = null;
-        return JSON.stringify(table, replacer, space);
+        this.replacer = null;
+        return JSON.stringify(table, null, space);
     }
 };
 


### PR DESCRIPTION
...ther than afterwards to the transformed Resurrect structure. This allows the replacer to remove keys and their associated values which should not be serialized. This is particularly important when the filtered out data is large.

Imagine an object like:
var myObj = {
  a: []
  b: { /\* huge data structure; not essential and can be recreated (e.g. for caching, reference data etc) */ }
};

This commit allows the replacer function to remove both "b" from myObj _and_ removes the associated value from serialized output. Rather than have JSON.stringify use the replacer function, we move this functionality inside the main serialization logic of Resurrect.
