### PR TITLE
properties filter by key and prototype property as class/constructor name for anonymous constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,17 @@ properties:
      and a prototype. Create a custom resolver if your constructors
      are not stored in global variables. The resolver has two methods:
      getName(object) and getPrototype(string).
+     
  * *propertiesFilter* (null): Function returning true when the property
      should be serialized, false when doesn't. It allows to choose what
      properties serialize or ignore depending on attribute value and name
      and the element that contains it. The function is evaluated for every
      attribute ant takes three parameters:
+     
  ** property name or key
+ 
  ** property value 
+ 
  ** the root element that contains the property
 
 For example,
@@ -143,6 +147,7 @@ will be call to guess the constructor's name (that will be invoked when
 deserialized). The function takes two parameters:
 * Object the constructor's name will guess from
 * The already guess name
+
 In the following example if the constructor's name is still undefined, it will
 be guessed from the _declaredClass attribute of the __proto__ attribute of the
 object.

--- a/README.md
+++ b/README.md
@@ -71,27 +71,12 @@ properties:
      are not stored in global variables. The resolver has two methods:
      getName(object) and getPrototype(string).
      
- * *propertiesFilter* (null): Function returning true when the property
-     should be serialized, false when doesn't. It allows to choose what
-     properties serialize or ignore depending on attribute value and name
-     and the element that contains it. The function is evaluated for every
-     attribute ant takes three parameters:
-
-   * property name or key
- 
-   * property value 
- 
-   * the root element that contains the property
-
 For example,
 
 ```javascript
 var necromancer = new Resurrect({
     prefix: '__#',
-    cleanup: true,
-    propertiesFilter: function(key, value, root) {
-						return key !== '_inherited';
-					}
+    cleanup: true
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,18 @@ properties:
      and a prototype. Create a custom resolver if your constructors
      are not stored in global variables. The resolver has two methods:
      getName(object) and getPrototype(string).
+     
  * *propertiesFilter* (null): Function returning true when the property
      should be serialized, false when doesn't. It allows to choose what
      properties serialize or ignore depending on attribute value and name
      and the element that contains it. The function is evaluated for every
      attribute ant takes three parameters:
- ** property name or key
- ** property value 
- ** the root element that contains the property
+     
+ --* property name or key
+ 
+ --* property value 
+ 
+ --* the root element that contains the property
 
 For example,
 
@@ -143,6 +147,7 @@ will be call to guess the constructor's name (that will be invoked when
 deserialized). The function takes two parameters:
 * Object the constructor's name will guess from
 * The already guess name
+
 In the following example if the constructor's name is still undefined, it will
 be guessed from the _declaredClass attribute of the __proto__ attribute of the
 object.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ properties:
      and a prototype. Create a custom resolver if your constructors
      are not stored in global variables. The resolver has two methods:
      getName(object) and getPrototype(string).
+ * *propertiesFilter* (null): Function returning true when the property
+     should be serialized, false when doesn't. It allows to choose what
+     properties serialize or ignore depending on attribute value and name
+     and the element that contains it. The function is evaluated for every
+     attribute ant takes three parameters:
+ ** property name or key
+ ** property value 
+ ** the root element that contains the property
 
 For example,
 
@@ -128,6 +136,36 @@ itself has been given a matching name. This is how the resolver will
 find the name of the constructor in the namespace when given the
 constructor. Keep in mind that using this form will bind the variable
 Foo to the surrounding function within the body of Foo.
+
+Additionally a constructor's name finder function can be also added as a 
+parameter for the nameresolver. When serializing an object this function 
+will be call to guess the constructor's name (that will be invoked when
+deserialized). The function takes two parameters:
+* Object the constructor's name will guess from
+* The already guess name
+In the following example if the constructor's name is still undefined, it will
+be guessed from the _declaredClass attribute of the __proto__ attribute of the
+object.
+
+~~~javascript
+var namespace = {};
+namespace.Foo = function Foo() {
+    this.bar = true;
+};
+var necromancer = new Resurrect({
+    resolver: new Resurrect.NamespaceResolver(
+    				namespace,
+    				function(object, constructor){
+						if (constructor === '') {
+					    	if (object.__proto__ && object.__proto__.declaredClass) {
+					    		return constructor = object.__proto__.declaredClass;
+					    	}
+					    } else {
+					    	return constructor;
+					    }
+					})
+});
+~~~
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ properties:
      and the element that contains it. The function is evaluated for every
      attribute ant takes three parameters:
 
- --* property name or key
+   * property name or key
  
- --* property value 
+   * property value 
  
- --* the root element that contains the property
+   * the root element that contains the property
 
 For example,
 

--- a/resurrect.js
+++ b/resurrect.js
@@ -57,9 +57,12 @@
  *     constructors are not stored in global variables. The resolver
  *     has two methods: getName(object) and getPrototype(string).
  *
- * 	 propertiesFilter null): Function returning true when the property
- * 	   should be serialized, false when doesn't. Takes three parameters:
- * 	   property name or key, its value and the root element that cotains it.
+ * 	 propertiesFilter (null): Function returning true when the property
+ *     should be serialized, false when doesn't. It allows to choose what
+ *     properties serialize or ignore depending on attribute value and name
+ *     and the element that contains it. The function is evaluated for every
+ *     attribute ant takes three parameters: property name or key, property
+ *     value and the root element that contains the property.
  *
  * For example,
  *

--- a/resurrect.js
+++ b/resurrect.js
@@ -386,7 +386,7 @@ Resurrect.prototype.visit = function(root, f, replacer) {
             root[this.refcode] = this.tag(copy);
             for (var key in root) {
                 var value = root[key];
-                if (root.hasOwnProperty(key) && this.propertiesFilter && this.propertiesFilter(key, value, root)) {
+                if (root.hasOwnProperty(key) && (!this.propertiesFilter || this.propertiesFilter(key, value, root))) {
                     if (replacer && value !== undefined) {
                         // Call replacer like JSON.stringify's replacer
                         value = replacer.call(root, key, root[key]);

--- a/resurrect.js
+++ b/resurrect.js
@@ -57,21 +57,12 @@
  *     constructors are not stored in global variables. The resolver
  *     has two methods: getName(object) and getPrototype(string).
  *
- * 	 propertiesFilter (null): Function returning true when the property
- *     should be serialized, false when doesn't. It allows to choose what
- *     properties serialize or ignore depending on attribute value and name
- *     and the element that contains it. The function is evaluated for every
- *     attribute ant takes three parameters: property name or key, property
- *     value and the root element that contains the property.
  *
  * For example,
  *
  * var necromancer = new Resurrect({
  *     prefix: '__#',
- *     cleanup: true,
- *     propertiesFilter:	function(key, value, root) {
- *								return key !== '_inherited';
- *							}
+ *     cleanup: true
  * });
  *
  * ## Caveats
@@ -389,7 +380,7 @@ Resurrect.prototype.visit = function(root, f, replacer) {
             root[this.refcode] = this.tag(copy);
             for (var key in root) {
                 var value = root[key];
-                if (root.hasOwnProperty(key) && (!this.propertiesFilter || this.propertiesFilter(key, value, root))) {
+                if (root.hasOwnProperty(key)) {
                     if (replacer && value !== undefined) {
                         // Call replacer like JSON.stringify's replacer
                         value = replacer.call(root, key, root[key]);


### PR DESCRIPTION
- exceptionKeys parameter in options to allow some properties of objects to be ignored in serialization. It is an array of the property keys to be ignored
- new parameter created also in NameResolver. When a class is created with an anonymous constructor it can't be serialized. This parameter points to the property in the prototype of the object to be used as name for constructor and key in the NameResolver. I used for some inheritance features of Dojo Toolkit that creates anonymous constructors but adds a declaredClass attribute in prototype with class name
