### PR TITLE
Add argument to control whether NamespaceResolver attempts to pair mangled constructors

### DIFF
--- a/resurrect.js
+++ b/resurrect.js
@@ -136,9 +136,11 @@ Resurrect.prototype.Error.prototype.name = 'ResurrectError';
  * Resolves prototypes through the properties on an object and
  * constructor names.
  * @param {Object} scope
+ * @param {boolean} resolveMangled
  * @constructor
  */
-Resurrect.NamespaceResolver = function(scope) {
+Resurrect.NamespaceResolver = function(scope, resolveMangled) {
+    this.resolveMangled = resolveMangled || false;
     this.scope = scope;
 };
 
@@ -177,6 +179,13 @@ Resurrect.NamespaceResolver.prototype.getName = function(object) {
     } else if (constructor === 'Object' || constructor === 'Array') {
         return null;
     } else {
+        if (this.resolveMangled) {
+            for (var prop in this.scope) {
+                if (this.scope.hasOwnProperty(prop) && this.scope[prop] === object.constructor) {
+                    return prop;
+                }
+            }
+        }
         return constructor;
     }
 };


### PR DESCRIPTION
I ran into a few issues with Resurrect-JS while messing with one of my scripts. Enabling variable mangle in uglify mangled constructor names and broke  NamespaceResolver. I was going to make my own or manually wrap the internal resolver but I came up with this change to automatically resolve my objects even if I update them later. I think it could be a really useful feature. 

I created a couple performance tests [here](http://jsperf.com/resurrectjs-uglify-mangle-compatibility-test/2). The (un-uglified) source object I used is below

```
var TestNamespace = {
    parent: (function() {
        function parent(name) {
            this.children = [];
            this.name = name;
        }

        parent.prototype.addChild = function(childToAdd) {
            this.children.push(childToAdd);
        }

        return parent;
    }()),
    child: (function() {
        function child(parent) {
            this.parent = parent;
        }

        child.prototype.check = function() {
            console.log('Child object check.');
        }

        return child;
    }())
};
```
